### PR TITLE
Update reference for cloud-set-guest-sshkey.sh in our Github repo

### DIFF
--- a/source/virtual_machines.rst
+++ b/source/virtual_machines.rst
@@ -1038,7 +1038,7 @@ Create an instance template that supports SSH Keys.
 
    .. sourcecode:: bash
 
-      wget http://downloads.sourceforge.net/project/cloudstack/SSH%20Key%20Gen%20Script/cloud-set-guest-sshkey.in?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Fcloudstack%2Ffiles%2FSSH%2520Key%2520Gen%2520Script%2F&ts=1331225219&use_mirror=iweb
+      wget https://raw.githubusercontent.com/apache/cloudstack/master/setup/bindir/cloud-set-guest-sshkey.in
 
 #. Copy the file to /etc/init.d.
 


### PR DESCRIPTION
There was a security issue reported in: https://issues.apache.org/jira/browse/CLOUDSTACK-7050 regarding the cloud-set-guest-sshkeys. The reporter was complaining about the script that appends the new key it receives to the authorized_keys list on the target VM.

Resetting SSH Keys in the admin guide seems to imply that once an SSH key pair is compromised that the resetSSHKeyForVirtualMachine API could be used to “reset” the SSH key for the VM but as mentioned the new key is merely appended to the list leaving the old compromised key.

The security issue was already fixed. However, our docs were pointing to an outdated version of that script. I am changing now the docs to point to the latest version of the cloud-set-guest-sshkeys.